### PR TITLE
Pulled in fix for reading block size in docker.

### DIFF
--- a/scripts/lib/wic/filemap.py
+++ b/scripts/lib/wic/filemap.py
@@ -36,8 +36,13 @@ def get_block_size(file_obj):
     """
     # Get the block size of the host file-system for the image file by calling
     # the FIGETBSZ ioctl (number 2).
-    binary_data = fcntl.ioctl(file_obj, 2, struct.pack('I', 0))
-    bsize = struct.unpack('I', binary_data)[0]
+    try:
+        binary_data = fcntl.ioctl(file_obj, 2, struct.pack('I', 0))
+        bsize = struct.unpack('I', binary_data)[0]
+    except OSError:
+        bsize = None
+
+    # If ioctl causes OSError or give bsize to zero failback to os.fstat
     if not bsize:
         import os
         stat = os.fstat(file_obj.fileno())


### PR DESCRIPTION
Pulled in a fix from upstream where determining the block size of a file would fail inside a docker container.

http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/scripts/lib/wic/filemap.py?id=b14588a77842f41613bd251165cce5bc95a708ad&context=9&ignorews=0&dt=0